### PR TITLE
Match the visionfive2 dtb file name and path with the uboot variable

### DIFF
--- a/mkvf2img.sh
+++ b/mkvf2img.sh
@@ -34,7 +34,7 @@ mdconfig -d -u 0
 mdconfig -a -t vnode -f efi.img -u 0
 mount_msdosfs /dev/md0 /mnt
 mkdir -p /mnt/dtb/starfive
-cp -v $DTB_FILE /mnt/dtb/starfive
+cp -v $DTB_FILE /mnt/dtb/starfive/starfive_visionfive2.dtb
 umount /dev/md0
 mdconfig -d -u 0
 


### PR DESCRIPTION
My uboot has the following variable for fdtfile:

fdtfile=starfive/starfive_visionfive2.dtb

If I place the dtb from this script there I can skip the manual boot configuration and boot automatically.

I have tested this my manually moving the dtb file in a stock freebsd 14 current image, but not with the script.